### PR TITLE
fix: 要約2回目APIコールの待機時間を3秒→10秒に延長

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -858,8 +858,8 @@ Log:\n${log}\n\nChat:\n${chat}`,
                 summarizeBtn.innerHTML = `<span class="text-sm">⏳</span><span>${t.statusReport1}</span>`;
                 const finalReport = await askAI([{ role: "user", parts: [{ text: p.exportReport(timeText, rawLogText, chatHistoryForReport) }] }], { useSearch: false });
 
-                // 2回連続リクエストによるレート制限を避けるため3秒待機
-                await new Promise(r => setTimeout(r, 3000));
+                // 2回連続リクエストによるレート制限を避けるため10秒待機
+                await new Promise(r => setTimeout(r, 10000));
 
                 summarizeBtn.innerHTML = `<span class="text-sm">⏳</span><span>${t.statusReport2}</span>`;
                 const cleanLog = await askAI([{ role: "user", parts: [{ text: p.exportClean(rawLogText) }] }], { useSearch: false });


### PR DESCRIPTION
429エラーのレート制限ウィンドウが約10秒で解除されることを確認。
1回目と2回目の要約コール間隔を10秒にすることで、
リトライなしで正常に通過できる確率を高める。

https://claude.ai/code/session_013i1ntnPJSSthz1ZMvxFZrn